### PR TITLE
Refactored mongodb_log to be usable as Framework

### DIFF
--- a/src/logger_registry.py
+++ b/src/logger_registry.py
@@ -1,0 +1,34 @@
+__author__ = 'Torben Hansing'
+
+
+__SPECIAL_LOGGERS = {}
+
+def register_logger(message, logger):
+    """
+    Registers a special logger for the given message type.
+    The `message` must be the python class of the message type.
+
+    :param message: The message type to register the logger for
+    :type message: Message
+    :param logger: The special logger to Register
+    :type logger: LoggerProcess
+    """
+    global __SPECIAL_LOGGERS
+    __SPECIAL_LOGGERS[message] = logger
+
+
+def get_logger(message, default=None):
+    """
+    Returns the special logger for the given message type.
+    If no special logger is found, the default will be returned.
+
+    :param message: The message type to search the logger for
+    :type message: Message
+    :param default: An optional fallback default to return if no special logger is found
+    :type default: MongoDBLogger | None
+    :return: The special logger registered for the given message type or the default
+    :rtype: MongoDBLogger|None
+    """
+    if message in __SPECIAL_LOGGERS:
+        return __SPECIAL_LOGGERS[message]
+    return default

--- a/src/mongodb_log.py
+++ b/src/mongodb_log.py
@@ -487,7 +487,7 @@ class MongoWriter(object):
             started = datetime.now()
 
             if self.graph_daemon and self.graph_process.poll() != None:
-                print("WARNING: rrdcached died, falling back to non-cached version. Please investigate.")
+                rospy.logwarn("rrdcached died, falling back to non-cached version. Please investigate.")
                 self.graph_daemon = False
 
             self.update_rrd()

--- a/src/mongodb_log.py
+++ b/src/mongodb_log.py
@@ -57,9 +57,9 @@ from designator_integration_msgs.msg import DesignatorResponse
 from designator_integration_msgs.msg import Designator
 
 
+use_setproctitle = True
 try:
     from setproctitle import setproctitle
-    use_setproctitle = True
 except ImportError:
     use_setproctitle = False
 
@@ -351,7 +351,6 @@ class MongoWriter(object):
             print("All topics")
             self.ros_master = rosgraph.masterapi.Master(NODE_NAME_TEMPLATE % self.nodename_prefix)
             self.update_topics(restart=False)
-        rospy.init_node(NODE_NAME_TEMPLATE % self.nodename_prefix, anonymous=True)
         self.start_all_topics_timer()
 
     def subscribe_topics(self, topics):
@@ -550,7 +549,6 @@ class MongoWriter(object):
             size += pmem[0]
             rss += pmem[1]
             stack += pmem[2]
-        #print("Size: %d  RSS: %s  Stack: %s" % (size, rss, stack))
         return (size, rss, stack)
 
     def assert_rrd(self, file, *data_sources):
@@ -599,7 +597,6 @@ class MongoWriter(object):
                 td = datetime.now() - started
 
     def graph_rrd(self):
-        #print("Generating graphs")
         time_started = datetime.now()
         rrdtool.graph(["%s/logstats.png" % self.graph_dir,
                        "--start=-600", "--end=-10",
@@ -633,7 +630,6 @@ class MongoWriter(object):
 
         if self.graph_topics:
             for _, w in self.workers.items():
-                #worker_time_started = datetime.now()
                 rrdtool.graph(["%s/%s.png" % (self.graph_dir, w.collname),
                                "--start=-600", "--end=-10",
                                "--disable-rrdtool-tag", "--width=560",
@@ -663,9 +659,6 @@ class MongoWriter(object):
                                "GPRINT:drop:LAST:   Current\\:%8.2lf %s",
                                "GPRINT:drop:AVERAGE:Average\\:%8.2lf %s",
                                "GPRINT:drop:MAX:Maximum\\:%8.2lf %s\\n"])
-
-                #worker_time_elapsed = datetime.now() - worker_time_started
-                #print("Generated worker graph for %s, took %s" % (w.topic, worker_time_elapsed))
 
         rrdtool.graph(["%s/logmemory.png" % self.graph_dir,
                        "--start=-600", "--end=-10",
@@ -707,7 +700,6 @@ class MongoWriter(object):
             self.graph_pidfile = mktemp(prefix="rrd_", suffix=".pid")
             print("Starting rrdcached -l unix:%s -p %s -b %s -g" %
                   (self.graph_sockfile, self.graph_pidfile, self.graph_dir))
-            devnull = file('/dev/null', 'a+')
             self.graph_process = subprocess.Popen(["/usr/bin/rrdcached",
                                                    "-l", "unix:%s" % self.graph_sockfile,
                                                    "-p", self.graph_pidfile,
@@ -726,7 +718,6 @@ class MongoWriter(object):
         # we do not lock here, we are not interested in super-precise
         # values for this, but we do care for high performance processing
         qsize = 0
-        #print("Updating graphs")
         time_started = datetime.now()
         for _, w in self.workers.items():
             wqsize = w.queue.qsize()

--- a/src/mongodb_log.py
+++ b/src/mongodb_log.py
@@ -117,7 +117,7 @@ class MongoDBLogger(object):
         :return: True if this process should quit
         :rtype: bool
         """
-        return self.quit
+        return self.quit or rospy.is_shutdown()
 
     @property
     def process(self):
@@ -364,7 +364,7 @@ def main(argv):
 
     # Initialize the rospy node
     topic = args.topic[0]
-    name = "%sMongoDB_logger_%s" %(args.nodename_prefix, topic)
+    name = "%sMongoDB_logger_%s" % (args.nodename_prefix, topic)
     collection_name = topic.replace("/", "_") if topic[0] != "/" else topic[1:].replace("/", "_")
     nodename = "%smongodb_logger_%s" % (args.nodename_prefix, collection_name)
 

--- a/src/mongodb_log.py
+++ b/src/mongodb_log.py
@@ -22,7 +22,7 @@
 #  Read the full text in the LICENSE.GPL file in the doc directory.
 # make sure we aren't using floor division
 from __future__ import division, with_statement
-
+from argparse import ArgumentParser
 
 BACKLOG_WARN_LIMIT = 100
 STATS_GRAPHTIME = 60
@@ -61,16 +61,16 @@ from random import randint
 
 class Counter(object):
     def __init__(self, value=None, lock=True):
-        self.count = value or Value('i', 0, lock=lock)
-        self.mutex = Lock()
+        self.__value = value if value is not None else 0
+        self.mutex = lock if lock is not None else Lock()
 
     def increment(self, by=1):
         with self.mutex:
-            self.count.value += by
+            self.__value += by
 
     def value(self):
         with self.mutex:
-            return self.count.value
+            return self.__value
 
 
 SPECIAL_LOGGERS = {}
@@ -91,57 +91,49 @@ def register_logger(message, logger):
     SPECIAL_LOGGERS[message] = logger
 
 
-class MongoDBLogger(Process):
+class MongoDBLogger(object):
     """
     This is the abstract base class for all loggers, who want to log to a mongodb.
-    This class creates a process and collects all informations necessary to connect to a mongodb.
+    This class stores all information necessary to connect to a mongodb.
     It does _NOT_ create a connection to the MongoDB, as this might be done by special loggers.
     This class does also _NOT_ subscribe to a Topic for the same reason.
     """
 
     __metaclass__ = abc.ABCMeta
 
-    def __init__(self, id_, topic, collname, mongodb_host, mongodb_port, mongodb_name, nodename_prefix=""):
+    def __init__(self, name, topic, collname, mongodb_host, mongodb_port, mongodb_name):
         """
-        Creates a new instance of the MongoDBLogger. This creates a new process to use for logging a topic.
-        This collects all necessary information to initalize a logger.
-        This method does _NOT_ start the process, as this will be done by the `start()`-Method.
+        Creates a new instance of the MongoDBLogger and stores all necessary information to initialize a logger.
 
-        :param id_: The ID of this logger process
-        :type id_: int
+        :param name: The name of this logger used in logging output
+        :type name: str
         :param topic: The topic to log messages from
         :type topic: str
         :param collname: The name of the collection in the MongoDB to log messages to.
-        :type collnae: basestring
+        :type collnae: str
         :param mongodb_host:The hostname or ip of the host running the MongoDB
-        :type mongodb_host: basestring
+        :type mongodb_host: str
         :param mongodb_port: The port on which the MongoDB is running on
         :type mongodb_port: int
         :param mongodb_name: The name of the databse to use for logging
-        :type mongodb_name: basestring
-        :param nodename_prefix: An optional prefix to use for the name of this Process
-        :type nodename_prefix: basestring
+        :type mongodb_name: str
         :return: A new MonoDBLogger instance
         :rtype: MongoDBLogger
         """
-        super(MongoDBLogger, self).__init__(name="%smongodb_logger-%d-%s" % (nodename_prefix, id_, topic))
-        self.id = id_
+        self.name = name
         self.topic = topic
         self.collname = collname
         self.mongodb_host = mongodb_host
         self.mongodb_port = mongodb_port
         self.mongodb_name = mongodb_name
-        self.nodename_prefix = nodename_prefix
-        self.nodename = "%sMongoDBLogger_%d%s" % (nodename_prefix, id_, topic.replace("/", "_"))
-        self.quit = Value('i', 0)
+        self.quit = False
 
     def shutdown(self):
         """
         Shuts down the running process and joins it back to the calling process.
         """
         if not self.is_quit():
-            self.quit.value = 1
-        self.join()
+            self.quit = True
 
     def is_quit(self):
         """
@@ -149,7 +141,7 @@ class MongoDBLogger(Process):
         :return: True if this process should quit
         :rtype: bool
         """
-        return self.quit.value == 1
+        return self.quit
 
     @property
     def process(self):
@@ -157,10 +149,17 @@ class MongoDBLogger(Process):
         Returns the process object of this Logger.
         This property is designed to be overwritten by subclasses to return the correct process object.
 
-        :return: The process doint the actual logging
+        :return: The process doing the actual logging
         :rtype: Process
         """
         return self
+
+    def start(self):
+        """
+        Starts the process by calling the `run()`-Method.
+        HACK: This is just a hack because I don't know if it will be replaced by processes.
+        """
+        self.run()
 
     @abc.abstractmethod
     def run(self):
@@ -180,9 +179,8 @@ class TopicLogger(MongoDBLogger):
     It simply dumps all messages received from the topic into the MongoDB.
     """
 
-    def __init__(self, id_, topic, collname, mongodb_host, mongodb_port, mongodb_name, nodename_prefix,
-                 max_queuesize=QUEUE_MAXSIZE):
-        MongoDBLogger.__init__(self, id_, topic, collname, mongodb_host, mongodb_port, mongodb_name, nodename_prefix)
+    def __init__(self, topic, collname, mongodb_host, mongodb_port, mongodb_name, max_queuesize=QUEUE_MAXSIZE):
+        MongoDBLogger.__init__(self, topic, collname, mongodb_host, mongodb_port, mongodb_name)
         self.worker_out_counter = Counter()
         self.worker_in_counter = Counter()
         self.worker_drop_counter = Counter()
@@ -191,12 +189,8 @@ class TopicLogger(MongoDBLogger):
     def _init(self):
         """
         This method initializes this process.
-        It has to be called from within the child process, therefore it has to be called in the `run()`-Method.
-        It initializes a new ros node, the connection to the MongoDB and subscribes to the topic.
+        It initializes the connection to the MongoDB and subscribes to the topic.
         """
-        rospy.logdebug("Inializing node %s" % self.nodename)
-        rospy.init_node(self.nodename, anonymous=False)
-
         self.mongoconn = Connection(self.mongodb_host, self.mongodb_port)
         self.mongodb = self.mongoconn[self.mongodb_name]
         self.mongodb.set_profiling_level = SLOW_ONLY
@@ -220,8 +214,7 @@ class TopicLogger(MongoDBLogger):
 
     def run(self):
         """
-        Runs the process.
-        This method is called by the child process to do the actual logging.
+        This method does the actual logging.
         """
         self._init()
         rospy.logdebug("ACTIVE: %s" % self.name)
@@ -234,7 +227,7 @@ class TopicLogger(MongoDBLogger):
         self.subscriber.unregister()
         self.subscriber = None
         while not self.queue.empty():
-            t = self.queue.get_nowait()
+            self.queue.get_nowait()
         rospy.logdebug("STOPPED: %s" % self.name)
 
     def shutdown(self):
@@ -278,7 +271,7 @@ class TopicLogger(MongoDBLogger):
         try:
             t = self.queue.get(True)
         except IOError:
-            self.quit.value = 1
+            self.quit = True
             return
         if isinstance(t, tuple):
             self.worker_out_counter.increment()
@@ -295,7 +288,7 @@ class TopicLogger(MongoDBLogger):
                 except (InvalidStringData, InvalidDocument), e:
                     rospy.logerr("%s %s@%s:\n%s" % (e.__class__.__name__, current_process().name, topic, e))
         else:
-            self.quit.value = 1
+            self.quit = True
 
 
 class CPPLogger(MongoDBLogger):
@@ -303,32 +296,30 @@ class CPPLogger(MongoDBLogger):
     This class implements a base class for spezialized loggers using other languages (like C++).
     """
 
-    def __init__(self, idnum, topic, collname, mongodb_host, mongodb_port, mongodb_name, nodename_prefix, cpp_logger,
+    def __init__(self, name, topic, collname, mongodb_host, mongodb_port, mongodb_name, nodename_prefix, cpp_logger,
                  additional_parameters):
         """
         Creates a new instance of the CPPLogger.
-        :param id_: The ID of this logger process
-        :type id_: int
+        :param name: The name of this logger used in logging output
+        :type name: str
         :param topic: The topic to log messages from
-        :type topic: basestring
+        :type topic: str
         :param collname: The name of the collection in the MongoDB to log messages to.
-        :type collnae: basestring
+        :type collnae: str
         :param mongodb_host:The hostname or ip of the host running the MongoDB
-        :type mongodb_host: basestring
+        :type mongodb_host: str
         :param mongodb_port: The port on which the MongoDB is running on
         :type mongodb_port: int
         :param mongodb_name: The name of the databse to use for logging
-        :type mongodb_name: basestring
-        :param nodename_prefix: An optional prefix to use for the name of this Process
-        :type nodename_prefix: basestring
+        :type mongodb_name: str
         :param cpp_logger: The path to the executable to use for the actual logging
-        :type cpp_logger: basestring
+        :type cpp_logger: str
         :param additional_parameters: Optional additional parameters to give to the logger
-        :type additional_parameters: [basestring]
+        :type additional_parameters: [str]
         :return: A new CPPLogger instance
         :rtype: CPPLogger
         """
-        super(CPPLogger, self).__init__(idnum, topic, collname, mongodb_host, mongodb_port, mongodb_name, nodename_prefix)
+        super(CPPLogger, self).__init__(name, topic, collname, mongodb_host, mongodb_port, mongodb_name)
         self.worker_out_counter = Counter()
         self.worker_in_counter = Counter()
         self.worker_drop_counter = Counter()
@@ -336,13 +327,11 @@ class CPPLogger(MongoDBLogger):
         self.additional_parameters = additional_parameters if additional_parameters is not None else []
         self.cpp_logger = cpp_logger
         self.__process = None
+        self.nodename = self.name.lower().replace("/", "_")
 
     @property
     def process(self):
         return self.__process
-
-    def qsize(self):
-        return self.qsize
 
     def run(self):
         mongodb_host_port = "%s:%d" % (self.mongodb_host, self.mongodb_port)
@@ -368,471 +357,63 @@ class CPPLogger(MongoDBLogger):
         self.__process.wait()
 
 
-class MongoWriter(object):
-    """
-    This class acts as the root node for all loggers.
-    If initializes the different loggers for each topic given and writes stats them.
-    """
-
-    __special_logger = {}
-
-    def __init__(self, topics=None, graph_topics=False,
-                 graph_dir=".", graph_clear=False, graph_daemon=False,
-                 all_topics=False, all_topics_interval=5,
-                 exclude_topics=None,
-                 mongodb_host=None, mongodb_port=None, mongodb_name="roslog",
-                 no_specific=False, nodename_prefix="", stats_looptime=0):
-        self.graph_dir = graph_dir
-        self.graph_topics = graph_topics
-        self.graph_clear = graph_clear
-        self.graph_daemon = graph_daemon
-        self.all_topics = all_topics
-        self.all_topics_interval = all_topics_interval
-        self.exclude_topics = exclude_topics if exclude_topics is not None else []
-        self.mongodb_host = mongodb_host
-        self.mongodb_port = mongodb_port
-        self.mongodb_name = mongodb_name
-        self.no_specific = no_specific
-        self.nodename_prefix = nodename_prefix
-        self.quit = False
-        self.topics = set()
-        self.sep = "\n"  # '\033[2J\033[;H'
-        self.workers = {}
-        self.stats_looptime = stats_looptime
-
-        if self.graph_dir == ".":
-            self.graph_dir = os.getcwd()
-        if not os.path.exists(self.graph_dir):
-            os.makedirs(self.graph_dir)
-        self.exclude_regex = []
-        for et in self.exclude_topics:
-            self.exclude_regex.append(re.compile(et))
-        self.exclude_already = []
-
-        self.init_rrd()
-
-        self.subscribe_topics(set(topics if topics is not None else []))
-        if self.all_topics:
-            rospy.logdebug("All topics")
-            self.ros_master = rosgraph.masterapi.Master(NODE_NAME_TEMPLATE % self.nodename_prefix)
-            self.update_topics(restart=False)
-        self.start_all_topics_timer()
-
-    @classmethod
-    def registerLogger(cls, msgClass, logger_class):
-        cls.__special_logger[msgClass] = logger_class
-
-    def subscribe_topics(self, topics):
-        for topic in topics:
-            if topic and topic[-1] == '/':
-                topic = topic[:-1]
-
-            if topic in self.topics:
-                continue
-            if topic in self.exclude_already:
-                continue
-
-            do_continue = False
-            for tre in self.exclude_regex:
-                if tre.match(topic):
-                    rospy.loginfo("*** IGNORING topic %s due to exclusion rule" % topic)
-                    do_continue = True
-                    self.exclude_already.append(topic)
-                    break
-            if do_continue:
-                continue
-
-            # although the collections is not strictly necessary, since MongoDB could handle
-            # pure topic names as collection names and we could then use mongodb[topic], we want
-            # to have names that go easier with the query tools, even though there is the theoretical
-            # possibility of name classes (hence the check)
-            collname = topic.replace("/", "_")[1:]
-            if collname in self.workers.keys():
-                rospy.logwarn("Two converted topic names clash: %s, ignoring topic %s"
-                      % (collname, topic))
-            else:
-                rospy.loginfo("Adding topic %s" % topic)
-                self.workers[collname] = self.create_worker(len(self.workers), topic, collname)
-                self.topics |= {topic}
-
-    def create_worker(self, idnum, topic, collname):
+def create_worker(self, name, topic, mongodb_host, mongodb_port, mongodb_name, collname, no_specific=False):
         msg_class, _, _ = rostopic.get_topic_class(topic, blocking=True)
         logger = None
-        if not self.no_specific and msg_class in SPECIAL_LOGGERS:
+        if not no_specific and msg_class in SPECIAL_LOGGERS:
             loggerClass = SPECIAL_LOGGERS[msg_class]
             try:
-                logger = loggerClass(idnum, topic, collname, self.mongodb_host, self.mongodb_port, self.mongodb_name,
-                                     self.nodename_prefix)
+                logger = loggerClass(name, topic, collname, mongodb_host, mongodb_port, mongodb_name)
             except Exception, e:
                 rospy.logerr(e.message)
-
         if logger is None:
-            logger = TopicLogger(idnum, topic, collname, self.mongodb_host, self.mongodb_port, self.mongodb_name,
-                                 self.nodename_prefix)
-
-        if self.graph_topics:
-            self.assert_worker_rrd(collname)
+            logger = TopicLogger(name, topic, collname, mongodb_host, mongodb_port, mongodb_name)
         return logger
-
-    def run(self):
-        for worker in self.workers.itervalues():
-            worker.start()
-
-        self.graph_thread = Thread(name="RRDGrapherThread", target=self.graph_rrd_thread)
-        self.graph_thread.daemon = True
-        self.graph_thread.start()
-        looping_threshold = timedelta(0, self.stats_looptime, 0)
-
-        while not rospy.is_shutdown() and not self.quit:
-            started = datetime.now()
-
-            if self.graph_daemon and self.graph_process.poll() != None:
-                rospy.logwarn("rrdcached died, falling back to non-cached version. Please investigate.")
-                self.graph_daemon = False
-
-            self.update_rrd()
-
-            # the following code makes sure we run once per STATS_LOOPTIME, taking
-            # varying run-times and interrupted sleeps into account
-            td = datetime.now() - started
-            while not rospy.is_shutdown() and not self.quit and td < looping_threshold:
-                sleeptime = self.stats_looptime - (td.microseconds + (td.seconds + td.days * 24 * 3600) * 10 ** 6) / 10 ** 6
-                if sleeptime > 0:
-                    sleep(sleeptime)
-                td = datetime.now() - started
-
-    def shutdown(self):
-        self.quit = True
-        if hasattr(self, "all_topics_timer"):
-            self.all_topics_timer.cancel()
-        for name, w in self.workers.items():
-            w.shutdown()
-
-        if self.graph_daemon:
-            self.graph_process.kill()
-            self.graph_process.wait()
-
-    def start_all_topics_timer(self):
-        if not self.all_topics or self.quit:
-            return
-        self.all_topics_timer = Timer(self.all_topics_interval, self.update_topics)
-        self.all_topics_timer.start()
-
-    def update_topics(self, restart=True):
-        if not self.all_topics or self.quit:
-            return
-        ts = self.ros_master.getPublishedTopics("/")
-        topics = set([t for t, t_type in ts if t != "/rosout" and t != "/rosout_agg"])
-        new_topics = topics - self.topics
-        self.subscribe_topics(new_topics)
-        if restart:
-            self.start_all_topics_timer()
-
-    def get_memory_usage_for_pid(self, pid):
-
-        scale = {'kB': 1024, 'mB': 1024 * 1024,
-                 'KB': 1024, 'MB': 1024 * 1024}
-        try:
-            f = open("/proc/%d/status" % pid)
-            t = f.read()
-            f.close()
-        except:
-            return (0, 0, 0)
-
-        if t == "":
-            return (0, 0, 0)
-
-        try:
-            tmp = t[t.index("VmSize:"):].split(None, 3)
-            size = int(tmp[1]) * scale[tmp[2]]
-            tmp = t[t.index("VmRSS:"):].split(None, 3)
-            rss = int(tmp[1]) * scale[tmp[2]]
-            tmp = t[t.index("VmStk:"):].split(None, 3)
-            stack = int(tmp[1]) * scale[tmp[2]]
-            return (size, rss, stack)
-        except ValueError:
-            return (0, 0, 0)
-
-    def get_memory_usage(self):
-        size, rss, stack = 0, 0, 0
-        for w in self.workers.itervalues():
-            if w.process is not None:
-                pmem = self.get_memory_usage_for_pid(w.process.pid)
-                size += pmem[0]
-                rss += pmem[1]
-                stack += pmem[2]
-        return (size, rss, stack)
-
-    def assert_rrd(self, file, *data_sources):
-        if not os.path.isfile(file) or self.graph_clear:
-            rrdtool.create(file, "--step", "10", "--start", "0",
-                           # remember that we always need to add the previous RRA time range
-                           # hence number of rows is not directly calculated by desired time frame
-                           "RRA:AVERAGE:0.5:1:720",     # 2 hours of 10 sec  averages
-                           "RRA:AVERAGE:0.5:3:1680",    # 12 hours of 30 sec  averages
-                           "RRA:AVERAGE:0.5:30:456",    # 1 day   of  5 min  averages
-                           "RRA:AVERAGE:0.5:180:412",   # 7 days  of 30 min  averages
-                           "RRA:AVERAGE:0.5:720:439",   # 4 weeks of  2 hour averages
-                           "RRA:AVERAGE:0.5:8640:402",  # 1 year  of  1 day averages
-                           "RRA:MIN:0.5:1:720",
-                           "RRA:MIN:0.5:3:1680",
-                           "RRA:MIN:0.5:30:456",
-                           "RRA:MIN:0.5:180:412",
-                           "RRA:MIN:0.5:720:439",
-                           "RRA:MIN:0.5:8640:402",
-                           "RRA:MAX:0.5:1:720",
-                           "RRA:MAX:0.5:3:1680",
-                           "RRA:MAX:0.5:30:456",
-                           "RRA:MAX:0.5:180:412",
-                           "RRA:MAX:0.5:720:439",
-                           "RRA:MAX:0.5:8640:402",
-                           *data_sources)
-
-    def graph_rrd_thread(self):
-        graphing_threshold = timedelta(0, STATS_GRAPHTIME - STATS_GRAPHTIME * 0.01, 0)
-        first_run = True
-
-        while not rospy.is_shutdown() and not self.quit:
-            started = datetime.now()
-
-            if not first_run:
-                self.graph_rrd()
-            first_run = False
-
-            # the following code makes sure we run once per STATS_LOOPTIME, taking
-            # varying run-times and interrupted sleeps into account
-            td = datetime.now() - started
-            while not rospy.is_shutdown() and not self.quit and td < graphing_threshold:
-                sleeptime = STATS_GRAPHTIME - (td.microseconds + (td.seconds + td.days * 24 * 3600) * 10 ** 6) / 10 ** 6
-                if sleeptime > 0:
-                    sleep(sleeptime)
-                td = datetime.now() - started
-
-    def graph_rrd(self):
-        time_started = datetime.now()
-        rrdtool.graph(["%s/logstats.png" % self.graph_dir,
-                       "--start=-600", "--end=-10",
-                       "--disable-rrdtool-tag", "--width=560",
-                       "--font", "LEGEND:10:", "--font", "UNIT:8:",
-                       "--font", "TITLE:12:", "--font", "AXIS:8:",
-                       "--title=MongoDB Logging Stats",
-                       "--vertical-label=messages/sec",
-                       "--slope-mode"]
-                      + (self.graph_daemon and self.graph_daemon_args or []) +
-                      ["DEF:qsize=%s/logstats.rrd:qsize:AVERAGE:step=10" % self.graph_dir,
-                       "DEF:in=%s/logstats.rrd:in:AVERAGE:step=10" % self.graph_dir,
-                       "DEF:out=%s/logstats.rrd:out:AVERAGE:step=10" % self.graph_dir,
-                       "DEF:drop=%s/logstats.rrd:drop:AVERAGE:step=10" % self.graph_dir,
-                       "LINE1:qsize#FF7200:Queue Size",
-                       "GPRINT:qsize:LAST:Current\\:%8.2lf %s",
-                       "GPRINT:qsize:AVERAGE:Average\\:%8.2lf %s",
-                       "GPRINT:qsize:MAX:Maximum\\:%8.2lf %s\\n",
-                       "LINE1:in#503001:In",
-                       "GPRINT:in:LAST:        Current\\:%8.2lf %s",
-                       "GPRINT:in:AVERAGE:Average\\:%8.2lf %s",
-                       "GPRINT:in:MAX:Maximum\\:%8.2lf %s\\n",
-                       "LINE1:out#EDAC00:Out",
-                       "GPRINT:out:LAST:       Current\\:%8.2lf %s",
-                       "GPRINT:out:AVERAGE:Average\\:%8.2lf %s",
-                       "GPRINT:out:MAX:Maximum\\:%8.2lf %s\\n",
-                       "LINE1:drop#506101:Dropped",
-                       "GPRINT:drop:LAST:   Current\\:%8.2lf %s",
-                       "GPRINT:drop:AVERAGE:Average\\:%8.2lf %s",
-                       "GPRINT:drop:MAX:Maximum\\:%8.2lf %s\\n"])
-
-        if self.graph_topics:
-            for _, w in self.workers.items():
-                rrdtool.graph(["%s/%s.png" % (self.graph_dir, w.collname),
-                               "--start=-600", "--end=-10",
-                               "--disable-rrdtool-tag", "--width=560",
-                               "--font", "LEGEND:10:", "--font", "UNIT:8:",
-                               "--font", "TITLE:12:", "--font", "AXIS:8:",
-                               "--title=%s" % w.topic,
-                               "--vertical-label=messages/sec",
-                               "--slope-mode"]
-                              + (self.graph_daemon and self.graph_daemon_args or []) +
-                              ["DEF:qsize=%s/%s.rrd:qsize:AVERAGE:step=10" % (self.graph_dir, w.collname),
-                               "DEF:in=%s/%s.rrd:in:AVERAGE:step=10" % (self.graph_dir, w.collname),
-                               "DEF:out=%s/%s.rrd:out:AVERAGE:step=10" % (self.graph_dir, w.collname),
-                               "DEF:drop=%s/%s.rrd:drop:AVERAGE:step=10" % (self.graph_dir, w.collname),
-                               "LINE1:qsize#FF7200:Queue Size",
-                               "GPRINT:qsize:LAST:Current\\:%8.2lf %s",
-                               "GPRINT:qsize:AVERAGE:Average\\:%8.2lf %s",
-                               "GPRINT:qsize:MAX:Maximum\\:%8.2lf %s\\n",
-                               "LINE1:in#503001:In",
-                               "GPRINT:in:LAST:        Current\\:%8.2lf %s",
-                               "GPRINT:in:AVERAGE:Average\\:%8.2lf %s",
-                               "GPRINT:in:MAX:Maximum\\:%8.2lf %s\\n",
-                               "LINE1:out#EDAC00:Out",
-                               "GPRINT:out:LAST:       Current\\:%8.2lf %s",
-                               "GPRINT:out:AVERAGE:Average\\:%8.2lf %s",
-                               "GPRINT:out:MAX:Maximum\\:%8.2lf %s\\n",
-                               "LINE1:drop#506101:Dropped",
-                               "GPRINT:drop:LAST:   Current\\:%8.2lf %s",
-                               "GPRINT:drop:AVERAGE:Average\\:%8.2lf %s",
-                               "GPRINT:drop:MAX:Maximum\\:%8.2lf %s\\n"])
-
-        rrdtool.graph(["%s/logmemory.png" % self.graph_dir,
-                       "--start=-600", "--end=-10",
-                       "--disable-rrdtool-tag", "--width=560",
-                       "--font", "LEGEND:10:", "--font", "UNIT:8:",
-                       "--font", "TITLE:12:", "--font", "AXIS:8:",
-                       "--title=ROS MongoLog Memory Usage",
-                       "--vertical-label=bytes",
-                       "--slope-mode"]
-                      + (self.graph_daemon and self.graph_daemon_args or []) +
-                      ["DEF:size=%s/logmemory.rrd:size:AVERAGE:step=10" % self.graph_dir,
-                       "DEF:rss=%s/logmemory.rrd:rss:AVERAGE:step=10" % self.graph_dir,
-                       "AREA:size#FF7200:Total",
-                       "GPRINT:size:LAST:   Current\\:%8.2lf %s",
-                       "GPRINT:size:AVERAGE:Average\\:%8.2lf %s",
-                       "GPRINT:size:MAX:Maximum\\:%8.2lf %s\\n",
-                       "AREA:rss#503001:Resident",
-                       "GPRINT:rss:LAST:Current\\:%8.2lf %s",
-                       "GPRINT:rss:AVERAGE:Average\\:%8.2lf %s",
-                       "GPRINT:rss:MAX:Maximum\\:%8.2lf %s\\n"])
-        time_elapsed = datetime.now() - time_started
-        rospy.logdebug("Generated graphs, took %s" % time_elapsed)
-
-    def init_rrd(self):
-        self.assert_rrd("%s/logstats.rrd" % self.graph_dir,
-                        "DS:qsize:GAUGE:30:0:U",
-                        "DS:in:COUNTER:30:0:U",
-                        "DS:out:COUNTER:30:0:U",
-                        "DS:drop:COUNTER:30:0:U")
-
-        self.assert_rrd("%s/logmemory.rrd" % self.graph_dir,
-                        "DS:size:GAUGE:30:0:U",
-                        "DS:rss:GAUGE:30:0:U",
-                        "DS:stack:GAUGE:30:0:U")
-
-        self.graph_args = []
-        if self.graph_daemon:
-            self.graph_sockfile = mktemp(prefix="rrd_", suffix=".sock")
-            self.graph_pidfile = mktemp(prefix="rrd_", suffix=".pid")
-            rospy.loginfo("Starting rrdcached -l unix:%s -p %s -b %s -g" %
-                  (self.graph_sockfile, self.graph_pidfile, self.graph_dir))
-            self.graph_process = subprocess.Popen(["/usr/bin/rrdcached",
-                                                   "-l", "unix:%s" % self.graph_sockfile,
-                                                   "-p", self.graph_pidfile,
-                                                   "-b", self.graph_dir,
-                                                   "-g"], stderr=subprocess.STDOUT)
-            self.graph_daemon_args = ["--daemon", "unix:%s" % self.graph_sockfile]
-
-    def assert_worker_rrd(self, collname):
-        self.assert_rrd("%s/%s.rrd" % (self.graph_dir, collname),
-                        "DS:qsize:GAUGE:30:0:U",
-                        "DS:in:COUNTER:30:0:U",
-                        "DS:out:COUNTER:30:0:U",
-                        "DS:drop:COUNTER:30:0:U")
-
-    def update_rrd(self):
-        # we do not lock here, we are not interested in super-precise
-        # values for this, but we do care for high performance processing
-        qsize = 0
-        time_started = datetime.now()
-        in_counter = 0
-        out_counter = 0
-        drop_counter = 0
-        for _, w in self.workers.items():
-            in_counter += w.worker_in_counter.count.value
-            out_counter += w.worker_out_counter.count.value
-            drop_counter += w.worker_drop_counter.count.value
-            wqsize = w.queue.qsize()
-            qsize += wqsize
-            if wqsize > QUEUE_MAXSIZE / 2:
-                rospy.logwarn("Excessive queue size %6d: %s" % (wqsize, w.name))
-
-            if self.graph_topics:
-                rrdtool.update(["%s/%s.rrd" % (self.graph_dir, w.collname)]
-                               + (self.graph_daemon and self.graph_daemon_args or []) +
-                               ["N:%d:%d:%d:%d" %
-                                (wqsize, w.worker_in_counter.count.value,
-                                 w.worker_out_counter.count.value, w.worker_drop_counter.count.value)])
-
-        rrdtool.update(["%s/logstats.rrd" % self.graph_dir]
-                       + (self.graph_daemon and self.graph_daemon_args or []) +
-                       ["N:%d:%d:%d:%d" %
-                        (qsize, in_counter, out_counter, drop_counter)])
-
-        rrdtool.update(["%s/logmemory.rrd" % self.graph_dir]
-                       + (self.graph_daemon and self.graph_daemon_args or []) +
-                       ["N:%d:%d:%d" % self.get_memory_usage()])
-
-        time_elapsed = datetime.now() - time_started
-        rospy.logdebug("Updated graphs, total queue size %d, dropped %d, took %s" %
-                       (qsize, drop_counter, time_elapsed))
 
 
 def main(argv):
-    parser = OptionParser()
-    parser.usage += " [TOPICs...]"
-    parser.add_option("--nodename-prefix", dest="nodename_prefix",
-                      help="Prefix for worker node names", metavar="ROS_NODE_NAME",
-                      default="")
-    parser.add_option("--mongodb-host", dest="mongodb_host",
-                      help="Hostname of MongoDB", metavar="HOST",
-                      default="localhost")
-    parser.add_option("--mongodb-port", dest="mongodb_port",
-                      help="Hostname of MongoDB", type="int",
-                      metavar="PORT", default=27017)
-    parser.add_option("--mongodb-name", dest="mongodb_name",
+    parser = ArgumentParser(description="Start a new logger")
+    parser.add_argument("--nodename-prefix", dest="nodename_prefix",
+                        help="Prefix for worker node names", metavar="ROS_NODE_NAME",
+                        default="")
+    parser.add_argument("--mongodb-host", dest="mongodb_host",
+                        help="Hostname of MongoDB", metavar="HOST",
+                        default="localhost")
+    parser.add_argument("--mongodb-port", dest="mongodb_port",
+                       help="Hostname of MongoDB", type="int",
+                       metavar="PORT", default=27017)
+    parser.add_argument("--mongodb-name", dest="mongodb_name",
                       help="Name of DB in which to store values",
                       metavar="NAME", default="roslog")
-    parser.add_option("-a", "--all-topics", dest="all_topics", default=False,
-                      action="store_true",
-                      help="Log all existing topics (still excludes /rosout, /rosout_agg)")
-    parser.add_option("--all-topics-interval", dest="all_topics_interval", default=5,
-                      help="Time in seconds between checks for new topics", type="int")
-    parser.add_option("-x", "--exclude", dest="exclude",
-                      help="Exclude topics matching REGEX, may be given multiple times",
-                      action="append", type="string", metavar="REGEX", default=[])
-    parser.add_option("--graph-topics", dest="graph_topics", default=False,
-                      action="store_true",
-                      help="Write graphs per topic")
-    parser.add_option("--graph-clear", dest="graph_clear", default=False,
-                      action="store_true",
-                      help="Remove existing RRD files.")
-    parser.add_option("--graph-dir", dest="graph_dir", default=".",
-                      help="Directory in which to create the graphs")
-    parser.add_option("--graph-daemon", dest="graph_daemon", default=False,
-                      action="store_true",
-                      help="Use rrddaemon.")
-    parser.add_option("--no-specific", dest="no_specific", default=False,
-                      action="store_true", help="Disable specific loggers")
-    parser.add_option("--stats-looptime", dest="stats_looptime", default=0,
-                      type=int, help="Record stats every x seconds")
-    (options, args) = parser.parse_args()
+    parser.add_argument("--no-specific", dest="no_specific", default=False,
+                        action="store_true", help="Disable specific loggers")
+    parser.add_argument("topic", metavar="TOPIC", type=str, nargs="1",
+                        help="The topic to subscribe to")
+    args = parser.parse_args()
 
-    if not options.all_topics and len(args) == 0:
-        parser.print_help()
-        return
+    # Initialize the rospy node
+    name = "%sMongoDB_logger%s" %(args.nodename_prefix, args.topic)
 
     try:
-        rosgraph.masterapi.Master(NODE_NAME_TEMPLATE % options.nodename_prefix).getPid()
+        rosgraph.masterapi.Master(NODE_NAME_TEMPLATE % args.nodename_prefix).getPid()
     except socket.error:
         rospy.logerr("Failed to communicate with master")
+
 
     # Register specialized loggers
     from special_loggers import register_special_loggers
     register_special_loggers()
 
-    mongowriter = MongoWriter(topics=rospy.myargv(args), graph_topics=options.graph_topics,
-                              graph_dir=options.graph_dir,
-                              graph_clear=options.graph_clear,
-                              graph_daemon=options.graph_daemon,
-                              all_topics=options.all_topics,
-                              all_topics_interval=options.all_topics_interval,
-                              exclude_topics=options.exclude,
-                              mongodb_host=options.mongodb_host,
-                              mongodb_port=options.mongodb_port,
-                              mongodb_name=options.mongodb_name,
-                              no_specific=options.no_specific,
-                              nodename_prefix=options.nodename_prefix,
-                              stats_looptime=options.stats_looptime)
+    nodename = name.lower().replace("/", "_")
+    rospy.init_node(nodename, anonymous=False)
 
-    mongowriter.run()
-    mongowriter.shutdown()
+    # Create the worker
+    logger = create_worker(name, args.topic, args.mongodb_host, args.mongodb_port,
+                  args.mongodb_name, args.topic.replace("/", "_"), args.no_specific)
+
+    # Start the logger
+    logger.start()
+    logger.shutdown()
 
 
 if __name__ == "__main__":

--- a/src/special_loggers.py
+++ b/src/special_loggers.py
@@ -1,0 +1,190 @@
+from roslib.packages import find_node
+from mongodb_log import CPPLogger, PACKAGE_NAME
+import rospy
+
+
+__author__ = 'suturo'
+
+
+class TFLogger(CPPLogger):
+    def __init__(self, id_, topic, collname, in_counter_value, out_counter_value, drop_counter_value, queue_maxsize,
+                 mongodb_host, mongodb_port, mongodb_name, nodename_prefix):
+        node_path = find_node(PACKAGE_NAME, "mongodb_log_tf")
+        # Log only when the preceeding entry of that
+        # transformation had at least 0.100 vectorial and radial
+        # distance to its predecessor transformation, but at least
+        # every second.
+        additional_parameters = ["-k" "0.100" "-l" "0.100" "-g" "1"]
+        if not node_path:
+            raise RuntimeError("FAILED to detect mongodb_log_tf, falling back to generic logger (did not build package?)")
+
+        super(TFLogger, self).__init__(id_, topic, collname, in_counter_value, out_counter_value, drop_counter_value,
+                                       queue_maxsize, mongodb_host, mongodb_port, mongodb_name, nodename_prefix,
+                                       node_path[0], additional_parameters)
+
+    @classmethod
+    def register(cls, writer):
+        try:
+            from tf.msg import tfMessage
+            writer.registerLogger(tfMessage, cls)
+        except ImportError:
+            rospy.logwarn("Can't register for message type tfMessage")
+        try:
+            from tf2_msgs.msg import TFMessage
+            writer.registerLogger(TFMessage, cls)
+        except ImportError:
+            rospy.logwarn("Can't register for message type TFMessage")
+
+
+class PointCloudLogger(CPPLogger):
+    def __init__(self, id_, topic, collname, in_counter_value, out_counter_value, drop_counter_value, queue_maxsize,
+                 mongodb_host, mongodb_port, mongodb_name, nodename_prefix):
+
+        node_path = find_node(PACKAGE_NAME, "mongodb_log_pcl")
+        if not node_path:
+            raise RuntimeError("FAILED to detect mongodb_log_pcl, falling back to generic logger (did not build package?)")
+        super(PointCloudLogger, self).__init__(id_, topic, collname, in_counter_value, out_counter_value,
+                                               drop_counter_value, queue_maxsize, mongodb_host, mongodb_port,
+                                               mongodb_name, nodename_prefix, node_path[0], None)
+
+    @classmethod
+    def register(cls, writer):
+        try:
+            from sensor_msgs.msg import PointCloud
+            writer.registerLogger(PointCloud, cls)
+        except ImportError:
+            rospy.logwarn("Can't register for message type PointCloud")
+
+
+class ImageLogger(CPPLogger):
+    def __init__(self, id_, topic, collname, in_counter_value, out_counter_value, drop_counter_value, queue_maxsize,
+                 mongodb_host, mongodb_port, mongodb_name, nodename_prefix):
+
+        node_path = find_node(PACKAGE_NAME, "mongodb_log_img")
+        if not node_path:
+            raise RuntimeError("FAILED to detect mongodb_log_img, falling back to generic logger (did not build package?)")
+        super(ImageLogger, self).__init__(id_, topic, collname, in_counter_value, out_counter_value,
+                                          drop_counter_value, queue_maxsize, mongodb_host, mongodb_port,
+                                          mongodb_name, nodename_prefix, node_path[0], None)
+
+    @classmethod
+    def register(cls, writer):
+        try:
+            from sensor_msgs.msg import Image
+            writer.registerLogger(Image, cls)
+        except ImportError:
+            rospy.logwarn("Can't register for message type Image")
+
+
+class CompressedImageLogger(CPPLogger):
+    def __init__(self, id_, topic, collname, in_counter_value, out_counter_value, drop_counter_value, queue_maxsize,
+                 mongodb_host, mongodb_port, mongodb_name, nodename_prefix):
+
+        node_path = find_node(PACKAGE_NAME, "mongodb_log_cimg")
+        if not node_path:
+            raise RuntimeError("FAILED to detect mongodb_log_cimg, falling back to generic logger (did not build package?)")
+        super(CompressedImageLogger, self).__init__(id_, topic, collname, in_counter_value, out_counter_value,
+                                          drop_counter_value, queue_maxsize, mongodb_host, mongodb_port,
+                                          mongodb_name, nodename_prefix, node_path[0], None)
+
+    @classmethod
+    def register(cls, writer):
+        try:
+            from sensor_msgs.msg import CompressedImage
+            writer.registerLogger(CompressedImage, cls)
+        except ImportError:
+            rospy.logwarn("Can't register for message type CompressedImage")
+
+
+class DesignatorRequestLogger(CPPLogger):
+    def __init__(self, id_, topic, collname, in_counter_value, out_counter_value, drop_counter_value, queue_maxsize,
+                 mongodb_host, mongodb_port, mongodb_name, nodename_prefix):
+
+        node_path = find_node(PACKAGE_NAME, "mongodb_log_desig")
+        additional_parameters = ["-d" "designator-request"]
+        if not node_path:
+            raise RuntimeError("FAILED to detect mongodb_log_desig, falling back to generic logger (did not build package?)")
+        super(DesignatorRequestLogger, self).__init__(id_, topic, collname, in_counter_value, out_counter_value,
+                                                      drop_counter_value, queue_maxsize, mongodb_host, mongodb_port,
+                                                      mongodb_name, nodename_prefix, node_path[0], additional_parameters)
+
+    @classmethod
+    def register(cls, writer):
+        try:
+            from designator_integration_msgs.msg import DesignatorRequest
+            writer.registerLogger(DesignatorRequest, cls)
+        except ImportError:
+            rospy.logwarn("Can't register for message type DesignatorRequest")
+
+
+class DesignatorResponseLogger(CPPLogger):
+    def __init__(self, id_, topic, collname, in_counter_value, out_counter_value, drop_counter_value, queue_maxsize,
+                 mongodb_host, mongodb_port, mongodb_name, nodename_prefix):
+
+        node_path = find_node(PACKAGE_NAME, "mongodb_log_desig")
+        additional_parameters = ["-d" "designator-response"]
+        if not node_path:
+            raise RuntimeError("FAILED to detect mongodb_log_desig, falling back to generic logger (did not build package?)")
+        super(DesignatorResponseLogger, self).__init__(id_, topic, collname, in_counter_value, out_counter_value,
+                                                      drop_counter_value, queue_maxsize, mongodb_host, mongodb_port,
+                                                      mongodb_name, nodename_prefix, node_path[0], additional_parameters)
+
+    @classmethod
+    def register(cls, writer):
+        try:
+            from designator_integration_msgs.msg import DesignatorResponse
+            writer.registerLogger(DesignatorResponse, cls)
+        except ImportError:
+            rospy.logwarn("Can't register for message type DesignatorResponse")
+
+
+class DesignatorLogger(CPPLogger):
+    def __init__(self, id_, topic, collname, in_counter_value, out_counter_value, drop_counter_value, queue_maxsize,
+                 mongodb_host, mongodb_port, mongodb_name, nodename_prefix):
+
+        node_path = find_node(PACKAGE_NAME, "mongodb_log_desig")
+        additional_parameters = ["-d" "designator"]
+        if not node_path:
+            raise RuntimeError("FAILED to detect mongodb_log_desig, falling back to generic logger (did not build package?)")
+        super(DesignatorLogger, self).__init__(id_, topic, collname, in_counter_value, out_counter_value,
+                                                      drop_counter_value, queue_maxsize, mongodb_host, mongodb_port,
+                                                      mongodb_name, nodename_prefix, node_path[0], additional_parameters)
+
+    @classmethod
+    def register(cls, writer):
+        try:
+            from designator_integration_msgs.msg import Designator
+            writer.registerLogger(Designator, cls)
+        except ImportError:
+            rospy.logwarn("Can't register for message type Designator")
+
+
+class TriangleMeshLogger(CPPLogger):
+    def __init__(self, id_, topic, collname, in_counter_value, out_counter_value, drop_counter_value, queue_maxsize,
+                 mongodb_host, mongodb_port, mongodb_name, nodename_prefix):
+
+        node_path = find_node(PACKAGE_NAME, "mongodb_log_trimesh")
+        if not node_path:
+            raise RuntimeError("FAILED to detect mongodb_log_trimesh, falling back to generic logger (did not build package?)")
+        super(TriangleMeshLogger, self).__init__(id_, topic, collname, in_counter_value, out_counter_value,
+                                                 drop_counter_value, queue_maxsize, mongodb_host, mongodb_port,
+                                                 mongodb_name, nodename_prefix, node_path[0], None)
+
+    @classmethod
+    def register(cls, writer):
+        try:
+            from triangle_mesh_msgs.msg import TriangleMesh
+            writer.registerLogger(TriangleMesh, cls)
+        except ImportError:
+            rospy.logwarn("Can't register for message type TriangleMesh")
+
+
+def register_special_loggers(writer):
+    TFLogger.register(writer)
+    PointCloudLogger.register(writer)
+    ImageLogger.register(writer)
+    CompressedImageLogger.register(writer)
+    DesignatorRequestLogger.register(writer)
+    DesignatorResponseLogger.register(writer)
+    DesignatorLogger.register(writer)
+    TriangleMeshLogger.register(writer)

--- a/src/special_loggers.py
+++ b/src/special_loggers.py
@@ -7,7 +7,7 @@ __author__ = 'suturo'
 
 
 class TFLogger(CPPLogger):
-    def __init__(self, id_, topic, collname, mongodb_host, mongodb_port, mongodb_name, nodename_prefix):
+    def __init__(self, name, topic, collname, mongodb_host, mongodb_port, mongodb_name):
         node_path = find_node(PACKAGE_NAME, "mongodb_log_tf")
         # Log only when the preceeding entry of that
         # transformation had at least 0.100 vectorial and radial
@@ -17,8 +17,8 @@ class TFLogger(CPPLogger):
         if not node_path:
             raise RuntimeError("FAILED to detect mongodb_log_tf, falling back to generic logger (did not build package?)")
 
-        super(TFLogger, self).__init__(id_, topic, collname, mongodb_host, mongodb_port, mongodb_name, nodename_prefix,
-                                       node_path[0], additional_parameters)
+        super(TFLogger, self).__init__(name, topic, collname, mongodb_host, mongodb_port, mongodb_name, node_path[0],
+                                       additional_parameters)
 
     @classmethod
     def register(cls):
@@ -35,13 +35,13 @@ class TFLogger(CPPLogger):
 
 
 class PointCloudLogger(CPPLogger):
-    def __init__(self, id_, topic, collname, mongodb_host, mongodb_port, mongodb_name, nodename_prefix):
+    def __init__(self, name, topic, collname, mongodb_host, mongodb_port, mongodb_name):
 
         node_path = find_node(PACKAGE_NAME, "mongodb_log_pcl")
         if not node_path:
             raise RuntimeError("FAILED to detect mongodb_log_pcl, falling back to generic logger (did not build package?)")
-        super(PointCloudLogger, self).__init__(id_, topic, collname, mongodb_host, mongodb_port, mongodb_name,
-                                               nodename_prefix, node_path[0], None)
+        super(PointCloudLogger, self).__init__(name, topic, collname, mongodb_host, mongodb_port, mongodb_name,
+                                               node_path[0], None)
 
     @classmethod
     def register(cls):
@@ -53,12 +53,12 @@ class PointCloudLogger(CPPLogger):
 
 
 class ImageLogger(CPPLogger):
-    def __init__(self, id_, topic, collname, mongodb_host, mongodb_port, mongodb_name, nodename_prefix):
+    def __init__(self, name, topic, collname, mongodb_host, mongodb_port, mongodb_name):
 
         node_path = find_node(PACKAGE_NAME, "mongodb_log_img")
         if not node_path:
             raise RuntimeError("FAILED to detect mongodb_log_img, falling back to generic logger (did not build package?)")
-        super(ImageLogger, self).__init__(id_, topic, collname, mongodb_host, mongodb_port, mongodb_name, nodename_prefix,
+        super(ImageLogger, self).__init__(name, topic, collname, mongodb_host, mongodb_port, mongodb_name,
                                           node_path[0], None)
 
     @classmethod
@@ -71,12 +71,12 @@ class ImageLogger(CPPLogger):
 
 
 class CompressedImageLogger(CPPLogger):
-    def __init__(self, id_, topic, collname, mongodb_host, mongodb_port, mongodb_name, nodename_prefix):
+    def __init__(self, name, topic, collname, mongodb_host, mongodb_port, mongodb_name):
         node_path = find_node(PACKAGE_NAME, "mongodb_log_cimg")
         if not node_path:
             raise RuntimeError("FAILED to detect mongodb_log_cimg, falling back to generic logger (did not build package?)")
-        super(CompressedImageLogger, self).__init__(id_, topic, collname, mongodb_host, mongodb_port, mongodb_name,
-                                                    nodename_prefix, node_path[0], None)
+        super(CompressedImageLogger, self).__init__(name, topic, collname, mongodb_host, mongodb_port, mongodb_name,
+                                                    node_path[0], None)
 
     @classmethod
     def register(cls):
@@ -88,13 +88,13 @@ class CompressedImageLogger(CPPLogger):
 
 
 class DesignatorRequestLogger(CPPLogger):
-    def __init__(self, id_, topic, collname, mongodb_host, mongodb_port, mongodb_name, nodename_prefix):
+    def __init__(self, name, topic, collname, mongodb_host, mongodb_port, mongodb_name):
         node_path = find_node(PACKAGE_NAME, "mongodb_log_desig")
         additional_parameters = ["-d" "designator-request"]
         if not node_path:
             raise RuntimeError("FAILED to detect mongodb_log_desig, falling back to generic logger (did not build package?)")
-        super(DesignatorRequestLogger, self).__init__(id_, topic, collname, mongodb_host, mongodb_port,
-                                                      mongodb_name, nodename_prefix, node_path[0], additional_parameters)
+        super(DesignatorRequestLogger, self).__init__(name, topic, collname, mongodb_host, mongodb_port, mongodb_name,
+                                                      node_path[0], additional_parameters)
 
     @classmethod
     def register(cls):
@@ -106,13 +106,13 @@ class DesignatorRequestLogger(CPPLogger):
 
 
 class DesignatorResponseLogger(CPPLogger):
-    def __init__(self, id_, topic, collname, mongodb_host, mongodb_port, mongodb_name, nodename_prefix):
+    def __init__(self, name, topic, collname, mongodb_host, mongodb_port, mongodb_name):
         node_path = find_node(PACKAGE_NAME, "mongodb_log_desig")
         additional_parameters = ["-d" "designator-response"]
         if not node_path:
             raise RuntimeError("FAILED to detect mongodb_log_desig, falling back to generic logger (did not build package?)")
-        super(DesignatorResponseLogger, self).__init__(id_, topic, collname, mongodb_host, mongodb_port,
-                                                      mongodb_name, nodename_prefix, node_path[0], additional_parameters)
+        super(DesignatorResponseLogger, self).__init__(name, topic, collname, mongodb_host, mongodb_port, mongodb_name,
+                                                       node_path[0], additional_parameters)
 
     @classmethod
     def register(cls):
@@ -124,13 +124,13 @@ class DesignatorResponseLogger(CPPLogger):
 
 
 class DesignatorLogger(CPPLogger):
-    def __init__(self, id_, topic, collname, mongodb_host, mongodb_port, mongodb_name, nodename_prefix):
+    def __init__(self, name, topic, collname, mongodb_host, mongodb_port, mongodb_name):
         node_path = find_node(PACKAGE_NAME, "mongodb_log_desig")
         additional_parameters = ["-d" "designator"]
         if not node_path:
             raise RuntimeError("FAILED to detect mongodb_log_desig, falling back to generic logger (did not build package?)")
-        super(DesignatorLogger, self).__init__(id_, topic, collname, mongodb_host, mongodb_port,
-                                                      mongodb_name, nodename_prefix, node_path[0], additional_parameters)
+        super(DesignatorLogger, self).__init__(name, topic, collname, mongodb_host, mongodb_port, mongodb_name,
+                                               node_path[0], additional_parameters)
 
     @classmethod
     def register(cls):
@@ -142,12 +142,12 @@ class DesignatorLogger(CPPLogger):
 
 
 class TriangleMeshLogger(CPPLogger):
-    def __init__(self, id_, topic, collname, mongodb_host, mongodb_port, mongodb_name, nodename_prefix):
+    def __init__(self, name, topic, collname, mongodb_host, mongodb_port, mongodb_name):
         node_path = find_node(PACKAGE_NAME, "mongodb_log_trimesh")
         if not node_path:
             raise RuntimeError("FAILED to detect mongodb_log_trimesh, falling back to generic logger (did not build package?)")
-        super(TriangleMeshLogger, self).__init__(id_, topic, collname, mongodb_host, mongodb_port,
-                                                 mongodb_name, nodename_prefix, node_path[0], None)
+        super(TriangleMeshLogger, self).__init__(name, topic, collname, mongodb_host, mongodb_port, mongodb_name,
+                                                 node_path[0], None)
 
     @classmethod
     def register(cls):

--- a/src/special_loggers.py
+++ b/src/special_loggers.py
@@ -1,9 +1,10 @@
 from roslib.packages import find_node
-from mongodb_log import CPPLogger, PACKAGE_NAME, register_logger
+from mongodb_log import CPPLogger, PACKAGE_NAME
+import logger_registry
 import rospy
 
 
-__author__ = 'suturo'
+__author__ = 'Torben Hansing'
 
 
 class TFLogger(CPPLogger):
@@ -24,12 +25,12 @@ class TFLogger(CPPLogger):
     def register(cls):
         try:
             from tf.msg import tfMessage
-            register_logger(tfMessage, cls)
+            logger_registry.register_logger(tfMessage, cls)
         except ImportError:
             rospy.logwarn("Can't register for message type tfMessage")
         try:
             from tf2_msgs.msg import TFMessage
-            register_logger(TFMessage, cls)
+            logger_registry.register_logger(TFMessage, cls)
         except ImportError:
             rospy.logwarn("Can't register for message type TFMessage")
 
@@ -47,7 +48,7 @@ class PointCloudLogger(CPPLogger):
     def register(cls):
         try:
             from sensor_msgs.msg import PointCloud
-            register_logger(PointCloud, cls)
+            logger_registry.register_logger(PointCloud, cls)
         except ImportError:
             rospy.logwarn("Can't register for message type PointCloud")
 
@@ -65,7 +66,7 @@ class ImageLogger(CPPLogger):
     def register(cls):
         try:
             from sensor_msgs.msg import Image
-            register_logger(Image, cls)
+            logger_registry.register_logger(Image, cls)
         except ImportError:
             rospy.logwarn("Can't register for message type Image")
 
@@ -82,7 +83,7 @@ class CompressedImageLogger(CPPLogger):
     def register(cls):
         try:
             from sensor_msgs.msg import CompressedImage
-            register_logger(CompressedImage, cls)
+            logger_registry.register_logger(CompressedImage, cls)
         except ImportError:
             rospy.logwarn("Can't register for message type CompressedImage")
 
@@ -100,7 +101,7 @@ class DesignatorRequestLogger(CPPLogger):
     def register(cls):
         try:
             from designator_integration_msgs.msg import DesignatorRequest
-            register_logger(DesignatorRequest, cls)
+            logger_registry.register_logger(DesignatorRequest, cls)
         except ImportError:
             rospy.logwarn("Can't register for message type DesignatorRequest")
 
@@ -118,7 +119,7 @@ class DesignatorResponseLogger(CPPLogger):
     def register(cls):
         try:
             from designator_integration_msgs.msg import DesignatorResponse
-            register_logger(DesignatorResponse, cls)
+            logger_registry.register_logger(DesignatorResponse, cls)
         except ImportError:
             rospy.logwarn("Can't register for message type DesignatorResponse")
 
@@ -136,7 +137,7 @@ class DesignatorLogger(CPPLogger):
     def register(cls):
         try:
             from designator_integration_msgs.msg import Designator
-            register_logger(Designator, cls)
+            logger_registry.register_logger(Designator, cls)
         except ImportError:
             rospy.logwarn("Can't register for message type Designator")
 
@@ -153,17 +154,16 @@ class TriangleMeshLogger(CPPLogger):
     def register(cls):
         try:
             from triangle_mesh_msgs.msg import TriangleMesh
-            register_logger(TriangleMesh, cls)
+            logger_registry.register_logger(TriangleMesh, cls)
         except ImportError:
             rospy.logwarn("Can't register for message type TriangleMesh")
 
 
-def register_special_loggers():
-    TFLogger.register()
-    PointCloudLogger.register()
-    ImageLogger.register()
-    CompressedImageLogger.register()
-    DesignatorRequestLogger.register()
-    DesignatorResponseLogger.register()
-    DesignatorLogger.register()
-    TriangleMeshLogger.register()
+TFLogger.register()
+PointCloudLogger.register()
+ImageLogger.register()
+CompressedImageLogger.register()
+DesignatorRequestLogger.register()
+DesignatorResponseLogger.register()
+DesignatorLogger.register()
+TriangleMeshLogger.register()

--- a/src/special_loggers.py
+++ b/src/special_loggers.py
@@ -1,5 +1,5 @@
 from roslib.packages import find_node
-from mongodb_log import CPPLogger, PACKAGE_NAME
+from mongodb_log import CPPLogger, PACKAGE_NAME, register_logger
 import rospy
 
 
@@ -7,8 +7,7 @@ __author__ = 'suturo'
 
 
 class TFLogger(CPPLogger):
-    def __init__(self, id_, topic, collname, in_counter_value, out_counter_value, drop_counter_value, queue_maxsize,
-                 mongodb_host, mongodb_port, mongodb_name, nodename_prefix):
+    def __init__(self, id_, topic, collname, mongodb_host, mongodb_port, mongodb_name, nodename_prefix):
         node_path = find_node(PACKAGE_NAME, "mongodb_log_tf")
         # Log only when the preceeding entry of that
         # transformation had at least 0.100 vectorial and radial
@@ -18,173 +17,153 @@ class TFLogger(CPPLogger):
         if not node_path:
             raise RuntimeError("FAILED to detect mongodb_log_tf, falling back to generic logger (did not build package?)")
 
-        super(TFLogger, self).__init__(id_, topic, collname, in_counter_value, out_counter_value, drop_counter_value,
-                                       queue_maxsize, mongodb_host, mongodb_port, mongodb_name, nodename_prefix,
+        super(TFLogger, self).__init__(id_, topic, collname, mongodb_host, mongodb_port, mongodb_name, nodename_prefix,
                                        node_path[0], additional_parameters)
 
     @classmethod
-    def register(cls, writer):
+    def register(cls):
         try:
             from tf.msg import tfMessage
-            writer.registerLogger(tfMessage, cls)
+            register_logger(tfMessage, cls)
         except ImportError:
             rospy.logwarn("Can't register for message type tfMessage")
         try:
             from tf2_msgs.msg import TFMessage
-            writer.registerLogger(TFMessage, cls)
+            register_logger(TFMessage, cls)
         except ImportError:
             rospy.logwarn("Can't register for message type TFMessage")
 
 
 class PointCloudLogger(CPPLogger):
-    def __init__(self, id_, topic, collname, in_counter_value, out_counter_value, drop_counter_value, queue_maxsize,
-                 mongodb_host, mongodb_port, mongodb_name, nodename_prefix):
+    def __init__(self, id_, topic, collname, mongodb_host, mongodb_port, mongodb_name, nodename_prefix):
 
         node_path = find_node(PACKAGE_NAME, "mongodb_log_pcl")
         if not node_path:
             raise RuntimeError("FAILED to detect mongodb_log_pcl, falling back to generic logger (did not build package?)")
-        super(PointCloudLogger, self).__init__(id_, topic, collname, in_counter_value, out_counter_value,
-                                               drop_counter_value, queue_maxsize, mongodb_host, mongodb_port,
-                                               mongodb_name, nodename_prefix, node_path[0], None)
+        super(PointCloudLogger, self).__init__(id_, topic, collname, mongodb_host, mongodb_port, mongodb_name,
+                                               nodename_prefix, node_path[0], None)
 
     @classmethod
-    def register(cls, writer):
+    def register(cls):
         try:
             from sensor_msgs.msg import PointCloud
-            writer.registerLogger(PointCloud, cls)
+            register_logger(PointCloud, cls)
         except ImportError:
             rospy.logwarn("Can't register for message type PointCloud")
 
 
 class ImageLogger(CPPLogger):
-    def __init__(self, id_, topic, collname, in_counter_value, out_counter_value, drop_counter_value, queue_maxsize,
-                 mongodb_host, mongodb_port, mongodb_name, nodename_prefix):
+    def __init__(self, id_, topic, collname, mongodb_host, mongodb_port, mongodb_name, nodename_prefix):
 
         node_path = find_node(PACKAGE_NAME, "mongodb_log_img")
         if not node_path:
             raise RuntimeError("FAILED to detect mongodb_log_img, falling back to generic logger (did not build package?)")
-        super(ImageLogger, self).__init__(id_, topic, collname, in_counter_value, out_counter_value,
-                                          drop_counter_value, queue_maxsize, mongodb_host, mongodb_port,
-                                          mongodb_name, nodename_prefix, node_path[0], None)
+        super(ImageLogger, self).__init__(id_, topic, collname, mongodb_host, mongodb_port, mongodb_name, nodename_prefix,
+                                          node_path[0], None)
 
     @classmethod
-    def register(cls, writer):
+    def register(cls):
         try:
             from sensor_msgs.msg import Image
-            writer.registerLogger(Image, cls)
+            register_logger(Image, cls)
         except ImportError:
             rospy.logwarn("Can't register for message type Image")
 
 
 class CompressedImageLogger(CPPLogger):
-    def __init__(self, id_, topic, collname, in_counter_value, out_counter_value, drop_counter_value, queue_maxsize,
-                 mongodb_host, mongodb_port, mongodb_name, nodename_prefix):
-
+    def __init__(self, id_, topic, collname, mongodb_host, mongodb_port, mongodb_name, nodename_prefix):
         node_path = find_node(PACKAGE_NAME, "mongodb_log_cimg")
         if not node_path:
             raise RuntimeError("FAILED to detect mongodb_log_cimg, falling back to generic logger (did not build package?)")
-        super(CompressedImageLogger, self).__init__(id_, topic, collname, in_counter_value, out_counter_value,
-                                          drop_counter_value, queue_maxsize, mongodb_host, mongodb_port,
-                                          mongodb_name, nodename_prefix, node_path[0], None)
+        super(CompressedImageLogger, self).__init__(id_, topic, collname, mongodb_host, mongodb_port, mongodb_name,
+                                                    nodename_prefix, node_path[0], None)
 
     @classmethod
-    def register(cls, writer):
+    def register(cls):
         try:
             from sensor_msgs.msg import CompressedImage
-            writer.registerLogger(CompressedImage, cls)
+            register_logger(CompressedImage, cls)
         except ImportError:
             rospy.logwarn("Can't register for message type CompressedImage")
 
 
 class DesignatorRequestLogger(CPPLogger):
-    def __init__(self, id_, topic, collname, in_counter_value, out_counter_value, drop_counter_value, queue_maxsize,
-                 mongodb_host, mongodb_port, mongodb_name, nodename_prefix):
-
+    def __init__(self, id_, topic, collname, mongodb_host, mongodb_port, mongodb_name, nodename_prefix):
         node_path = find_node(PACKAGE_NAME, "mongodb_log_desig")
         additional_parameters = ["-d" "designator-request"]
         if not node_path:
             raise RuntimeError("FAILED to detect mongodb_log_desig, falling back to generic logger (did not build package?)")
-        super(DesignatorRequestLogger, self).__init__(id_, topic, collname, in_counter_value, out_counter_value,
-                                                      drop_counter_value, queue_maxsize, mongodb_host, mongodb_port,
+        super(DesignatorRequestLogger, self).__init__(id_, topic, collname, mongodb_host, mongodb_port,
                                                       mongodb_name, nodename_prefix, node_path[0], additional_parameters)
 
     @classmethod
-    def register(cls, writer):
+    def register(cls):
         try:
             from designator_integration_msgs.msg import DesignatorRequest
-            writer.registerLogger(DesignatorRequest, cls)
+            register_logger(DesignatorRequest, cls)
         except ImportError:
             rospy.logwarn("Can't register for message type DesignatorRequest")
 
 
 class DesignatorResponseLogger(CPPLogger):
-    def __init__(self, id_, topic, collname, in_counter_value, out_counter_value, drop_counter_value, queue_maxsize,
-                 mongodb_host, mongodb_port, mongodb_name, nodename_prefix):
-
+    def __init__(self, id_, topic, collname, mongodb_host, mongodb_port, mongodb_name, nodename_prefix):
         node_path = find_node(PACKAGE_NAME, "mongodb_log_desig")
         additional_parameters = ["-d" "designator-response"]
         if not node_path:
             raise RuntimeError("FAILED to detect mongodb_log_desig, falling back to generic logger (did not build package?)")
-        super(DesignatorResponseLogger, self).__init__(id_, topic, collname, in_counter_value, out_counter_value,
-                                                      drop_counter_value, queue_maxsize, mongodb_host, mongodb_port,
+        super(DesignatorResponseLogger, self).__init__(id_, topic, collname, mongodb_host, mongodb_port,
                                                       mongodb_name, nodename_prefix, node_path[0], additional_parameters)
 
     @classmethod
-    def register(cls, writer):
+    def register(cls):
         try:
             from designator_integration_msgs.msg import DesignatorResponse
-            writer.registerLogger(DesignatorResponse, cls)
+            register_logger(DesignatorResponse, cls)
         except ImportError:
             rospy.logwarn("Can't register for message type DesignatorResponse")
 
 
 class DesignatorLogger(CPPLogger):
-    def __init__(self, id_, topic, collname, in_counter_value, out_counter_value, drop_counter_value, queue_maxsize,
-                 mongodb_host, mongodb_port, mongodb_name, nodename_prefix):
-
+    def __init__(self, id_, topic, collname, mongodb_host, mongodb_port, mongodb_name, nodename_prefix):
         node_path = find_node(PACKAGE_NAME, "mongodb_log_desig")
         additional_parameters = ["-d" "designator"]
         if not node_path:
             raise RuntimeError("FAILED to detect mongodb_log_desig, falling back to generic logger (did not build package?)")
-        super(DesignatorLogger, self).__init__(id_, topic, collname, in_counter_value, out_counter_value,
-                                                      drop_counter_value, queue_maxsize, mongodb_host, mongodb_port,
+        super(DesignatorLogger, self).__init__(id_, topic, collname, mongodb_host, mongodb_port,
                                                       mongodb_name, nodename_prefix, node_path[0], additional_parameters)
 
     @classmethod
-    def register(cls, writer):
+    def register(cls):
         try:
             from designator_integration_msgs.msg import Designator
-            writer.registerLogger(Designator, cls)
+            register_logger(Designator, cls)
         except ImportError:
             rospy.logwarn("Can't register for message type Designator")
 
 
 class TriangleMeshLogger(CPPLogger):
-    def __init__(self, id_, topic, collname, in_counter_value, out_counter_value, drop_counter_value, queue_maxsize,
-                 mongodb_host, mongodb_port, mongodb_name, nodename_prefix):
-
+    def __init__(self, id_, topic, collname, mongodb_host, mongodb_port, mongodb_name, nodename_prefix):
         node_path = find_node(PACKAGE_NAME, "mongodb_log_trimesh")
         if not node_path:
             raise RuntimeError("FAILED to detect mongodb_log_trimesh, falling back to generic logger (did not build package?)")
-        super(TriangleMeshLogger, self).__init__(id_, topic, collname, in_counter_value, out_counter_value,
-                                                 drop_counter_value, queue_maxsize, mongodb_host, mongodb_port,
+        super(TriangleMeshLogger, self).__init__(id_, topic, collname, mongodb_host, mongodb_port,
                                                  mongodb_name, nodename_prefix, node_path[0], None)
 
     @classmethod
-    def register(cls, writer):
+    def register(cls):
         try:
             from triangle_mesh_msgs.msg import TriangleMesh
-            writer.registerLogger(TriangleMesh, cls)
+            register_logger(TriangleMesh, cls)
         except ImportError:
             rospy.logwarn("Can't register for message type TriangleMesh")
 
 
-def register_special_loggers(writer):
-    TFLogger.register(writer)
-    PointCloudLogger.register(writer)
-    ImageLogger.register(writer)
-    CompressedImageLogger.register(writer)
-    DesignatorRequestLogger.register(writer)
-    DesignatorResponseLogger.register(writer)
-    DesignatorLogger.register(writer)
-    TriangleMeshLogger.register(writer)
+def register_special_loggers():
+    TFLogger.register()
+    PointCloudLogger.register()
+    ImageLogger.register()
+    CompressedImageLogger.register()
+    DesignatorRequestLogger.register()
+    DesignatorResponseLogger.register()
+    DesignatorLogger.register()
+    TriangleMeshLogger.register()


### PR DESCRIPTION
WIth this pull-request I've refactored the mongodb_log to create a Framework of it, so that new loggers can easily be registered.
I've also recreated the structure of the whole package, as it wasn't possible to use it in a launch file with a python-logger. This is because rospy only supports a single process per node and the old implementation tried to create multiple nodes. This caused a "Shutdown request: New node with the same name registered" when it was started from a launch file, because in a launch file the name of the node is given and therefore all Processes whould have the same name.
Now we create a seperate node for every topic we want to log. Therefore launch-files using the old implementation need to be refactored too.

The old RRD-Graph is now also a seperate, optional, process. Therefore each Logger publishes it's Stats to a topic called <NODENAME>_stats which will then be subscribed by the new Graph logger.
Therefore the API of the Graph-Logger changed: Instead of topics, it now get's the node names to watch.

I've created 3 Classes as the "Framework":
- MongoDBLogger: This is an abstract base class for all loggers.
- TopicLogger: This is the old "generic" Topic logger which just pushes the ROS-Messages into the MongoDB
- CPPLogger: This is the baseclass for all special loggers which are implemented in C / C++, it reads the Stats from the STDOUT and publishes them onto the topic, just like the old one did (except for the topic).
